### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Based on this GitHub issue: https://github.com/couchbase/couchbase-lite-net/issu
 
 
 
-#Data Other
+# Data Other
 
 [YAWL.Serialization](https://github.com/YAWL/YAWL.Serialization) Serialization helper library for Windows applications
 

--- a/Test/test.md
+++ b/Test/test.md
@@ -1,4 +1,4 @@
-#testing area for MD
+# testing area for MD
 
 :fuelpump: The UWP Tools List
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
